### PR TITLE
Pass regex syntax error on to the user.

### DIFF
--- a/src/retest.rs
+++ b/src/retest.rs
@@ -7,8 +7,9 @@ pub fn print_matches(pattern: &str, subject: &str, matches_only: bool) {
     // Attempt to compile the given regex pattern.
     let regex = match Regex::new(&pattern) {
         Ok(result) => { result },
-        Err(_) => {
-            println!("Invalid regular expression pattern '{}'.", pattern);
+        Err(err) => {
+            println!("Invalid regular expression pattern '{}': {}",
+                     pattern, err);
             return;
         }
     };


### PR DESCRIPTION
e.g., This:

```
$ retest '(a)|b)'
Invalid regular expression pattern '(a)|b)'.
```

becomes this

```
$ retest '(a)|b)'
Invalid regular expression pattern '(a)|b)': Error parsing regex near '(a)|b)' at character offset 5: Unopened parenthesis.
```
